### PR TITLE
Fix for VSCode argument interpretation change

### DIFF
--- a/code-open/src/main.rs
+++ b/code-open/src/main.rs
@@ -2,6 +2,7 @@ use clap::{App, Arg};
 use code_open_common::*;
 use path_absolutize::*;
 use std::io::Write;
+use std::path::MAIN_SEPARATOR;
 use std::{env, net::TcpStream, path::PathBuf};
 
 fn send_request_to_server(code_open_config: &CodeOpenConfig, code_open_req: CodeOpenRequest) {
@@ -83,17 +84,20 @@ fn main() {
         },
     );
 
-    let code_open_info = CodeOpenInfo::new(
-        gethostname::gethostname()
-            .to_str()
-            .expect("Failed: to_str")
-            .to_owned(),
-        path.absolutize()
-            .expect("Failed to absolutize")
-            .to_str()
-            .expect("Failed: to_str")
-            .to_owned(),
-    );
+    let remote_host_name = gethostname::gethostname()
+        .to_str()
+        .expect("Failed: to_str")
+        .to_owned();
+    let mut remote_dir_full_path = path
+        .absolutize()
+        .expect("Failed to absolutize")
+        .to_str()
+        .expect("Failed: to_str")
+        .to_owned();
+    if path.is_dir() {
+        remote_dir_full_path.push(MAIN_SEPARATOR);
+    }
+    let code_open_info = CodeOpenInfo::new(remote_host_name, remote_dir_full_path);
 
     let code_open_req = CodeOpenRequest::Open(code_open_info);
 


### PR DESCRIPTION
# 背景

- Linux の SSH 先から `.` を含むパスにあるディレクトリを Windows クライアント上の VSCode を開こうとすると、パス指定が上手くいかない問題がある
- パスが Windows 側でなんらかの解釈の結果他の形になっている、VSCode のコマンドライン引数の解釈をする部分の実装が変わったなどの原因が考えられる。

# 変更点

- 実際の原因は不明だがパスの末尾に `path::MAIN_SEPARATOR`  を追加することで解決できることがわかったので、`code-open` 側でリクエストを送る際に開く対象がディレクトリであれば `path::MAIN_SEPARATOR`  を追加するようにした。