### PR TITLE
Introduce clap derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,11 +45,26 @@ checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_derive",
  "indexmap",
+ "lazy_static",
  "os_str_bytes",
  "strsim",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -157,6 +172,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +201,12 @@ name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -233,6 +260,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bfa72956f6be8524f7f7e2b07972dda393cb0008a6df4451f658b7e1bd1af80"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -376,6 +427,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"

--- a/code-open-common/src/lib.rs
+++ b/code-open-common/src/lib.rs
@@ -109,22 +109,3 @@ pub struct CodeOpenConfig {
 
 pub static DEFAULT_IP: &str = "localhost";
 pub static DEFAULT_PORT: u16 = 3000;
-
-impl Default for CodeOpenConfig {
-    fn default() -> Self {
-        Self {
-            ip: DEFAULT_IP.to_owned(),
-            port: DEFAULT_PORT,
-        }
-    }
-}
-
-impl CodeOpenConfig {
-    pub fn set_ip(&mut self, ip: String) {
-        self.ip = ip;
-    }
-
-    pub fn set_port(&mut self, port: u16) {
-        self.port = port;
-    }
-}

--- a/code-open-server/src/main.rs
+++ b/code-open-server/src/main.rs
@@ -135,9 +135,10 @@ fn server_start(code_open_config: &CodeOpenConfig, table: &HashMap<String, Strin
 fn main() {
     let args = Args::parse();
 
-    let mut code_open_config = CodeOpenConfig::default();
-    code_open_config.set_ip(args.ip);
-    code_open_config.set_port(args.port);
+    let code_open_config = CodeOpenConfig {
+        ip: args.ip,
+        port: args.port,
+    };
 
     let table = load_local_configured_name_table();
     println!("Actual host name to locally configured host name in .ssh/config table:");

--- a/code-open-server/src/main.rs
+++ b/code-open-server/src/main.rs
@@ -1,10 +1,23 @@
-use clap::{Arg, Command as ClapCommand};
+use clap::Parser;
 use code_open_common::*;
 use once_cell::sync::Lazy;
 use std::path;
 use std::{collections::HashMap, fs::File};
 use std::{io::Read, net::TcpListener};
 use std::{io::Write, process::Command};
+
+/// open VSCode over SSH
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// ip address of the server to be connected
+    #[clap(short, long, default_value_t = DEFAULT_IP.to_string())]
+    ip: String,
+
+    /// port number of the server to be connected
+    #[clap(short, long, default_value_t = DEFAULT_PORT)]
+    port: u16,
+}
 
 static THIS_APP_NAME: &str = "code-open-server";
 static THIS_APP_CONFIG_BASE_PATH: Lazy<String> = Lazy::new(|| {
@@ -120,39 +133,11 @@ fn server_start(code_open_config: &CodeOpenConfig, table: &HashMap<String, Strin
 }
 
 fn main() {
+    let args = Args::parse();
+
     let mut code_open_config = CodeOpenConfig::default();
-    let default_port_str = DEFAULT_PORT.to_string();
-
-    let app = ClapCommand::new("code-open-server")
-        .version("0.1.0")
-        .author("Akihiro Shoji <alpha.kai.net@alpha-kai-net.info>")
-        .about("open VSCode over SSH Server")
-        .arg(
-            Arg::new("ip")
-                .required(false)
-                .short('i')
-                .long("ip")
-                .takes_value(true)
-                .default_value(DEFAULT_IP),
-        )
-        .arg(
-            Arg::new("port")
-                .required(false)
-                .short('p')
-                .long("port")
-                .takes_value(true)
-                .default_value(&default_port_str),
-        );
-
-    let matches = app.get_matches();
-
-    if let Some(ip) = matches.value_of("ip") {
-        code_open_config.set_ip(ip.to_owned());
-    }
-
-    if let Some(port) = matches.value_of("port") {
-        code_open_config.set_port(port.parse().expect("failed to parse given port number"));
-    }
+    code_open_config.set_ip(args.ip);
+    code_open_config.set_port(args.port);
 
     let table = load_local_configured_name_table();
     println!("Actual host name to locally configured host name in .ssh/config table:");

--- a/code-open/Cargo.toml
+++ b/code-open/Cargo.toml
@@ -14,4 +14,4 @@ rmp-serde = "1.0.0"
 gethostname = "0.2.3"
 shellexpand = "2.1.0"
 path-absolutize = "3.0.12"
-clap = "3.1.6"
+clap = { version = "3.1.6", features = ["derive"] }

--- a/code-open/src/main.rs
+++ b/code-open/src/main.rs
@@ -51,8 +51,7 @@ fn main() {
         port: args.port,
     };
 
-    let ssh_flag = env::vars().any(|(k, _)| k == "SSH_CONNECTION");
-    if !ssh_flag {
+    if env::var("SSH_CONNECTION").is_err() {
         println!("Error this command should be executed in SSH");
         return;
     }

--- a/code-open/src/main.rs
+++ b/code-open/src/main.rs
@@ -1,9 +1,24 @@
-use clap::{Arg, Command};
+use clap::Parser;
 use code_open_common::*;
 use path_absolutize::*;
 use std::io::Write;
 use std::path::MAIN_SEPARATOR;
 use std::{env, net::TcpStream, path::PathBuf};
+
+/// open VSCode over SSH
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// ip address of the server to be connected
+    #[clap(short, long, default_value_t = DEFAULT_IP.to_string())]
+    ip: String,
+
+    /// port number of the server to be connected
+    #[clap(short, long, default_value_t = DEFAULT_PORT)]
+    port: u16,
+
+    path: Option<String>,
+}
 
 fn send_request_to_server(code_open_config: &CodeOpenConfig, code_open_req: CodeOpenRequest) {
     let mut connection = TcpStream::connect((code_open_config.ip.as_str(), code_open_config.port))
@@ -32,52 +47,20 @@ fn main() {
     let ssh_flag = env::vars().any(|(k, _)| k == "SSH_CONNECTION");
     let mut code_open_config = CodeOpenConfig::default();
 
-    let default_port_str = &DEFAULT_PORT.to_string();
-
-    let app = Command::new("code-open")
-        .version("0.1.0")
-        .author("Akihiro Shoji <alpha.kai.net@alpha-kai-net.info>")
-        .about("open VSCode over SSH")
-        .arg(
-            Arg::new("ip")
-                .required(false)
-                .short('i')
-                .long("ip")
-                .takes_value(true)
-                .default_value(DEFAULT_IP)
-                .help("ip address of the server to be connected"),
-        )
-        .arg(
-            Arg::new("port")
-                .required(false)
-                .short('p')
-                .long("port")
-                .takes_value(true)
-                .default_value(default_port_str)
-                .help("port number of the server to be connected"),
-        )
-        .arg(Arg::new("path").required(false));
-
-    let matches = app.get_matches();
-
-    if let Some(ip) = matches.value_of("ip") {
-        code_open_config.set_ip(ip.to_owned());
-    }
-
-    if let Some(port) = matches.value_of("port") {
-        code_open_config.set_port(port.parse().expect("failed to parse given port number"));
-    }
+    let args = Args::parse();
+    code_open_config.set_ip(args.ip);
+    code_open_config.set_port(args.port);
 
     if !ssh_flag {
         println!("Error this command should be executed in SSH");
         return;
     }
 
-    let path = matches.value_of("path").map_or_else(
+    let path = args.path.map_or_else(
         || env::current_dir().unwrap(),
         |path| {
             PathBuf::from(
-                shellexpand::full(path)
+                shellexpand::full(&path)
                     .expect("failed to tilde expad")
                     .to_string(),
             )

--- a/code-open/src/main.rs
+++ b/code-open/src/main.rs
@@ -44,13 +44,14 @@ fn send_request_to_server(code_open_config: &CodeOpenConfig, code_open_req: Code
 }
 
 fn main() {
-    let ssh_flag = env::vars().any(|(k, _)| k == "SSH_CONNECTION");
-    let mut code_open_config = CodeOpenConfig::default();
-
     let args = Args::parse();
-    code_open_config.set_ip(args.ip);
-    code_open_config.set_port(args.port);
 
+    let code_open_config = CodeOpenConfig {
+        ip: args.ip,
+        port: args.port,
+    };
+
+    let ssh_flag = env::vars().any(|(k, _)| k == "SSH_CONNECTION");
     if !ssh_flag {
         println!("Error this command should be executed in SSH");
         return;


### PR DESCRIPTION
# 背景

- clap v3 で structopt が clap に統合されたため、構造体に引数をバインドする `derive` マクロが使えるようになった。

# 変更点

- この `derive` マクロを使う形に引数のパース部分を変更